### PR TITLE
run the MCP server on MCP_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ task build
 
 ## Usage
 
+### Server Configuration
+
+The server can be configured using environment variables:
+
+- `MCP_PORT`: The port number to run the server on (default: 8080)
+  - Must be a valid integer between 0 and 65535
+  - If invalid or not set, the server will use port 8080
+
+Example:
+```bash
+# Run on port 3000
+MCP_PORT=3000 ./osv-mcp
+
+# Run on default port 8080
+./build/osv-mcp-server
+```
 
 ### MCP Tools
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,15 +6,38 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/StacklokLabs/osv-mcp/pkg/mcp"
 	"github.com/StacklokLabs/osv-mcp/pkg/osv"
 )
 
+// getMCPServerPort returns the port number from MCP_PORT environment variable.
+// If the environment variable is not set or contains an invalid value,
+// it returns the default port 8080.
+func getMCPServerPort() string {
+	port := "8080"
+	if envPort := os.Getenv("MCP_PORT"); envPort != "" {
+		if portNum, err := strconv.Atoi(envPort); err == nil {
+			if portNum >= 0 && portNum <= 65535 {
+				port = envPort
+			} else {
+				log.Printf("Invalid MCP_PORT value: %s (must be between 0 and 65535), using default port 8080", envPort)
+			}
+		} else {
+			log.Printf("Invalid MCP_PORT value: %s (must be a valid number), using default port 8080", envPort)
+		}
+	}
+	return port
+}
+
 func main() {
+	// Get port from environment variable or use default
+	port := getMCPServerPort()
+
 	// Parse command-line flags
-	addr := flag.String("addr", ":8080", "Address to listen on")
+	addr := flag.String("addr", ":"+port, "Address to listen on")
 	flag.Parse()
 
 	// Create OSV client

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,63 @@ func TestCreateServer(t *testing.T) {
 	// Verify server properties
 	assert.Equal(t, mcp.ServerName, "osv-mcp")
 	assert.Equal(t, mcp.ServerVersion, "0.1.0")
+}
+
+func TestGetMCPServerPort(t *testing.T) {
+	// Save original env value and restore it after the test
+	originalPort := os.Getenv("MCP_PORT")
+	defer func() {
+		if originalPort != "" {
+			os.Setenv("MCP_PORT", originalPort)
+		} else {
+			os.Unsetenv("MCP_PORT")
+		}
+	}()
+
+	tests := []struct {
+		name     string
+		envPort  string
+		expected string
+	}{
+		{
+			name:     "No environment variable set",
+			envPort:  "",
+			expected: "8080",
+		},
+		{
+			name:     "Valid port number",
+			envPort:  "3000",
+			expected: "3000",
+		},
+		{
+			name:     "Invalid port (non-numeric)",
+			envPort:  "abc",
+			expected: "8080",
+		},
+		{
+			name:     "Invalid port (negative number)",
+			envPort:  "-1",
+			expected: "8080",
+		},
+		{
+			name:     "Invalid port (too large)",
+			envPort:  "70000",
+			expected: "8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment
+			if tt.envPort != "" {
+				os.Setenv("MCP_PORT", tt.envPort)
+			} else {
+				os.Unsetenv("MCP_PORT")
+			}
+
+			// Test the function
+			port := getMCPServerPort()
+			assert.Equal(t, tt.expected, port)
+		})
+	}
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -19,6 +19,8 @@ const (
 
 	// ServerVersion is the version of the MCP server
 	ServerVersion = "0.1.0"
+	// ServerPort is the port the MCP server will listen on
+	ServerPort = "8080"
 )
 
 // Server is an MCP server that provides OSV vulnerability information


### PR DESCRIPTION
Checks whether the MCP_PORT environment variable is set and valid for running the server. If the port is not specified or is invalid, the server runs on the default port.