### PR TITLE
Add ToolHive packaged usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ task build
 
 ## Usage
 
+### Running with ToolHive (Recommended)
+
+The easiest way to run the OSV MCP server is using [ToolHive](https://github.com/stacklok/toolhive), which provides secure, containerized deployment of MCP servers:
+
+```bash
+# Install ToolHive (if not already installed)
+# See: https://github.com/stacklok/toolhive#installation
+
+# Enable auto-discovery to automatically configure supported clients
+thv config auto-discovery true
+
+# Run the OSV MCP server (packaged as 'osv' in ToolHive)
+thv run osv
+
+# List running servers
+thv list
+
+# Get detailed information about the server
+thv registry info osv
+```
+
+The server will be available to your MCP-compatible clients and can query the OSV database for vulnerability information.
+
+### Running from Source
+
 ### Server Configuration
 
 The server can be configured using environment variables:


### PR DESCRIPTION
This PR adds instructions for running the OSV MCP server using ToolHive's packaged version.

## Changes

- Add instructions for running OSV MCP server using ToolHive's packaged 'osv' server
- Include ToolHive installation and auto-discovery setup
- Reorganize usage section to highlight ToolHive as recommended approach
- Maintain existing source-based installation instructions

## Usage

Users can now easily run the OSV MCP server with:

```bash
thv config auto-discovery true
thv run osv
```

This provides a much simpler deployment process compared to building from source.

## Benefits

- Simplified deployment process
- Automatic client configuration
- Secure containerized environment
- No need to install Go or build tools
- Consistent with ToolHive's packaged server approach